### PR TITLE
Bump django-celery-beat version

### DIFF
--- a/requirements-serv.txt
+++ b/requirements-serv.txt
@@ -5,7 +5,7 @@ django==2.2
 djangorestframework==3.11.0
 django-filter==2.2.0
 django-cors-headers==3.2.0
-django-celery-beat==1.5.0
+django-celery-beat==2.1.0
 celery[redis]
 channels==2.1.5
 channels_redis==2.3.1


### PR DESCRIPTION
This fixes errors with continuously crashing Celery workers.